### PR TITLE
fix - App Crashes At Startup

### DIFF
--- a/uikit/iOSTakeHomeChallenge/Models/Character.swift
+++ b/uikit/iOSTakeHomeChallenge/Models/Character.swift
@@ -8,7 +8,7 @@ struct Character: Codable {
     let culture: String
     let born: String
     let died: String
-    let aliases: [Int]
+    let aliases: [String]
     let tvSeries: [String]
     let playedBy: [String]
 }


### PR DESCRIPTION
Crash was caused due to DTO model incorrectly defined.